### PR TITLE
Remove "License" from the license description

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 about:
   home: https://urllib3.readthedocs.io/
-  license: MIT License
+  license: MIT
   summary: 'HTTP library with thread-safe connection pooling, file post, and more.'
 
 extra:


### PR DESCRIPTION
The new conda-forge linting service dislikes "License" in the description of the license.