### PR TITLE
install with pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set compress_type = "tar.gz" %}
 {% set hash_type = "sha256" %}
 {% set hash_val = "a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf" %}
-{% set build_num = "0" %}
+{% set build_num = "1" %}
 
 package:
   name: {{ name|lower }}
@@ -16,12 +16,12 @@ source:
 
 build:
   number: {{ build_num }}
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
     - python
-    - setuptools
+    - pip
 
   run:
     - python


### PR DESCRIPTION
Appears to fix permission issues in metadata files in tests (closes #13), which would be another reason to try to get to a point where zero packages are installed with `setup.py install`.