### PR TITLE
Change maintainers to be the same as PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@ocefpaf](https://github.com/ocefpaf/)
+* [@shazow](https://github.com/shazow/)
 * [@sethmlarson](https://github.com/sethmlarson/)
-* [@sigmavirus24](https://github.com/sigmavirus24/)
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - sigmavirus24
-    - ocefpaf
+    - shazow
     - sethmlarson


### PR DESCRIPTION
Removed @ocefpaf and @sigmavirus24 from the recipe maintainers so the same users with upload privileges on Conda are the same as PyPI.

This is nothing personal, it's purely for security surface reasons since this is part of the deployment pipeline. Thanks for maintaining the feedstock all this time :)